### PR TITLE
Eoran spells minor edit

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -41,7 +41,7 @@
 	range = 7
 	overlay_state = "love"
 	sound = list('sound/magic/magnet.ogg')
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross/eora)
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross) //CC Change
 	releasedrain = 40
 	chargetime = 60
 	warnie = "spellwarning"
@@ -81,7 +81,7 @@
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
 	chargedloop = null
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross/eora)
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross) //CC change
 	sound = 'sound/magic/whiteflame.ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
@@ -342,7 +342,7 @@
 	invocation = "Eora, nourish this offering!"
 	desc = "Bless a food item. Items that take longer to eat heal slower. Skilled clergy can bless food more often. Finer food heals more."
 	sound = 'sound/magic/magnet.ogg'
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross/eora)
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross) //CC change
 	devotion_cost = 25
 	recharge_time = 90 SECONDS
 	overlay_state = "bread"
@@ -378,7 +378,7 @@
 	invocation = "Eora, provide sanctuary for your beauty!"
 	desc = "Grow a cool tree."
 	sound = 'sound/magic/magnet.ogg'
-	req_items = list(/obj/item/clothing/neck/roguetown/psicross/eora)
+	req_items = list(/obj/item/clothing/neck/roguetown/psicross) //CC change
 	devotion_cost = 500
 	recharge_time = 5 SECONDS
 	chargetime = 1 SECONDS


### PR DESCRIPTION


## About The Pull Request
This brings the Eoran spells more inline to just check psycrosses and not just eoran psycrosses. This allows the eoran to get a spare cross from the churches storage rather than being tied to the merchant before the crosses run out. also allows the priest/priestess to cast eoran spell as they use an astratan psycross.

/obj/item/clothing/neck/roguetown/psicross/eora -> /obj/item/clothing/neck/roguetown/psicross
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
more consistency good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
